### PR TITLE
Add data.rc undefined to response condition check

### DIFF
--- a/js/mcumgr.js
+++ b/js/mcumgr.js
@@ -178,7 +178,7 @@ class MCUManager {
         const data = CBOR.decode(message.slice(8).buffer);
         const length = length_hi * 256 + length_lo;
         const group = group_hi * 256 + group_lo;
-        if (group === MGMT_GROUP_ID_IMAGE && id === IMG_MGMT_ID_UPLOAD && data.rc === 0 && data.off) {
+        if (group === MGMT_GROUP_ID_IMAGE && id === IMG_MGMT_ID_UPLOAD && (data.rc === 0 || data.rc === undefined) && data.off){
             this._uploadOffset = data.off;            
             this._uploadNext();
             return;


### PR DESCRIPTION
With the addition of the new SMP v2 protocol the legacy SMP(v1) also had it's response data changed. Previously, the response data would allways include the rc field, see https://docs.zephyrproject.org/3.4.0/services/device_mgmt/smp_protocol.html
e.g.:
```
{rc: 0 , off: 73}
{rc: 0 , off: 192}
{rc: 0 , off: 311}
```
Now, with latest releases, the rc field only appears if non-zero (error condition), see https://docs.zephyrproject.org/3.5.0/services/device_mgmt/smp_protocol.html

> “rc” | mcumgr_err_t only appears if non-zero (error condition) when using SMP version 1 or for SMP errors when using SMP version 2.

e.g.:
```
{off: 73}
{off: 192}
{off: 311}
```

There's a config added in Zephyr 3.3 (https://docs.zephyrproject.org/latest/releases/release-notes-3.3.html), that allows to disable this behaviour but is defaulted to "n", it can be enabled instead of using this fix:

> MCUmgr responses where rc (result code) is 0 (no error) will no longer be present in responses and in cases where there is only an rc result, the resultant response will now be an empty CBOR map. The old behaviour can be restored by enabling CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR.
