### PR TITLE
Only hash header and image (not TLV)

### DIFF
--- a/js/mcumgr.js
+++ b/js/mcumgr.js
@@ -301,7 +301,7 @@ class MCUManager {
         const version = `${view[20]}.${view[21]}.${view[22] + view[23] * 2**8}`;
         info.version = version;
 
-        info.hash = [...new Uint8Array(await this._hash(image.slice(0, imageSize + 32)))].map(b => b.toString(16).padStart(2, '0')).join('');
+        info.hash = [...new Uint8Array(await this._hash(image.slice(0, imageSize + headerSize)))].map(b => b.toString(16).padStart(2, '0')).join('');
 
         return info;
     }


### PR DESCRIPTION
The hash of an image should be computed as the SHA-256 of the header and image bytes; thus excluding the trailing TLV segment. Therefore, I fixed the `imageInfo` function to calculate the hash in the proper way.