### PR TITLE
Calculate hash with protected TLV region, extract TLVs and verify hash matches

### DIFF
--- a/js/mcumgr.js
+++ b/js/mcumgr.js
@@ -280,10 +280,8 @@ class MCUManager {
 
         const headerSize = view.getUint16(8, true);
 
-        // check protected TLV area size is 0
-        if (view.getUint16(10, true) !== 0x00) {
-            throw new Error('Invalid image (wrong protected TLV area size)');
-        }
+        // Protected TLV area is included in the hash
+        const protected_tlv_lenth = view.getUint16(10, true);
 
         const imageSize = view.getUint32(12, true);
         info.imageSize = imageSize;
@@ -301,7 +299,7 @@ class MCUManager {
         const version = `${view.getUint8(20)}.${view.getUint8(21)}.${view.getUint16(22, true)}`;
         info.version = version;
 
-        info.hash = [...new Uint8Array(await this._hash(image.slice(0, imageSize + headerSize)))].map(b => b.toString(16).padStart(2, '0')).join('');
+        info.hash = [...new Uint8Array(await this._hash(image.slice(0, imageSize + headerSize + protected_tlv_lenth)))].map(b => b.toString(16).padStart(2, '0')).join('');
 
         return info;
     }

--- a/js/mcumgr.js
+++ b/js/mcumgr.js
@@ -257,6 +257,20 @@ class MCUManager {
 
         this._uploadNext();
     }
+    // Given an ArrayBuffer, extract Tag-Value pairs and return them one by one.
+    *_extractTlvs(data) {
+        const view = new DataView(data);
+        let offset = 0;
+        while (offset < view.byteLength) {
+            const tag = view.getUint16(offset, true);
+            const len = view.getUint16(offset + 2, true);
+            offset += 4;
+            const data = view.buffer.slice(offset, offset + len);
+            offset += len;
+
+            yield { tag, value: new Uint8Array(data) };
+        }
+    }
     async imageInfo(image) {
         // https://interrupt.memfault.com/blog/mcuboot-overview#mcuboot-image-binaries
 
@@ -300,6 +314,42 @@ class MCUManager {
         info.version = version;
 
         info.hash = [...new Uint8Array(await this._hash(image.slice(0, imageSize + headerSize + protected_tlv_lenth)))].map(b => b.toString(16).padStart(2, '0')).join('');
+
+        let offset = headerSize + imageSize;
+        let tlv_end = offset;
+
+        // Only if it was indicated that there were protected TLVs
+        if (protected_tlv_lenth > 0) {
+            // Verify the protected TLV magic bytes are valid.
+            if (view.getUint16(offset, true) !== 0x6908) {
+                throw new Error( `Expected protected TLV magic number. (0x${offset.toString(16)}: 0x${view.getUint16(offset, true).toString(16)})`);
+            }
+
+            // Find the end of the protected TLV region
+            tlv_end = view.getUint16(offset + 2, true) + offset;
+            // Store all tag-value pairs for the protected TLV region.
+            for (let tlv of this._extractTlvs(view.buffer.slice(offset + 4, tlv_end))) {
+                info.tags[tlv.tag] = tlv.value;
+            }
+            offset = tlv_end;
+        }
+
+        // The non-protected TLV region must be here.
+        if (view.getUint16(offset, true) !== 0x6907) {
+            throw new Error(`Expected TLV magic number. (0x${offset.toString(16)}: 0x${view.getUint16(offset, true).toString(16)})`);
+        }
+
+        // Also include the non-protected TLVs in the tags map.
+        // Assume there are no overlapping tag Ids.
+        tlv_end = view.getUint16(offset + 2, true) + offset;
+        for (let tlv of this._extractTlvs(view.buffer.slice(offset + 4, tlv_end))) {
+            info.tags[tlv.tag] = tlv.value;
+        }
+
+        // If the image hash tag is present, verify it matches what was calculated earlier.
+        if (16 in info.tags && info.tags[16].length == hash.length) {
+            info.hashValid = info.tags[16].every((b, i) => b === hash[i]);
+        }
 
         return info;
     }


### PR DESCRIPTION
Hi there,

I've been using McuMgr in a project of mine for a while and have made a few changes of my own. This PR back ports support for Protected TLV parsing within the `imageInfo()` function. Useful for getting correct hash outputs for comparison.

1. Uses `DataView` instead of `Uint8Array` to improve readability of parsing the image header fields.
2. Extract the `protected_tlv_length` field to add to the length of data that needs to be hashed.
3. Extract TLV key value pairs into a map that could be useful i.e. accessing vendor information.