### PR TITLE
Fix reconnection delay handling

### DIFF
--- a/js/mcumgr.js
+++ b/js/mcumgr.js
@@ -84,7 +84,7 @@ class MCUManager {
             return;
         }
     }
-    _connect() {
+    _connect(delay = 1000) {
         setTimeout(async () => {
             try {
                 if (this._connectingCallback) this._connectingCallback();
@@ -103,7 +103,7 @@ class MCUManager {
                 this._logger.error(error);
                 await this._disconnected();
             }
-        }, 1000);
+        }, delay);
     }
     disconnect() {
         this._userRequestedDisconnect = true;


### PR DESCRIPTION
## Summary
- add a `delay` parameter to `_connect` to let callers specify how long to wait

## Testing
- `node -c js/mcumgr.js`
- `node -c js/index.js`


------
https://chatgpt.com/codex/tasks/task_e_683fd0b180f883338b55d5be34a6ef01