### PR TITLE
Fix browser compatibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This tool is the Web Bluetooth version of MCU Manager that enables a user to com
 
 The main focus is implementing firmware updates via Web Bluetooth, however other commands might be supported as well.
 
-The Web Bluetooth API provides the ability to connect and interact with Bluetooth Low Energy peripherals. You’ll find Web Bluetooth:
-- on the desktop (or laptop) in Chrome, Edge and Opera browsers (make sure you have the latest)
-- on Android phones in Chrome (perhaps in Edge or Opera?)
+The Web Bluetooth API provides the ability to connect and interact with Bluetooth Low Energy peripherals. You'll find Web Bluetooth:
+- on the desktop (or laptop) in Chrome and Edge browsers (make sure you have the latest). Other Chromium-based browsers may also work.
+- on Android phones in Chrome (perhaps in Edge or other Chromium-based browsers?)
 - on iOS or iPadOS there is [Bluefy](https://apps.apple.com/hu/app/bluefy-web-ble-browser/id1492822055) that seems to be working.
 
-Safari, Chrome, Edge and Opera on iOS are using the Safari WebKit engine which not yet supports Web Bluetooth. Mobile and desktop Firefox is not implemented it yet, too.
+Safari, Chrome, Edge on iOS are using the Safari WebKit engine which not yet supports Web Bluetooth. Mobile and desktop Firefox has not implemented it yet, too. Opera restricts Web Bluetooth access.
 
 You can try MCU Manager by visiting https://boogie.github.io/mcumgr-web/ with a supported browser. For security reasons, Web Bluetooth is only working on https addresses or localhost.
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div class="content" id="initial-screen">
         <div class="alert alert-primary" role="alert" id="bluetooth-is-available">
             <b><span id="bluetooth-is-available-message"></span></b>
-            This tool is compatible with desktops (or laptops) with the <b>latest Chrome, Opera and Edge</b> browsers, and working
+            This tool is compatible with desktops (or laptops) with the <b>latest Chrome and Edge</b> browsers (other Chromium-based browsers may also work), and working
             Bluetooth connection (most laptops have them these days). You can also try it from Chrome on Android, or Bluefy on iOS/iPadOS.
         </div>
         <div id="connect-block" style="display: none;">


### PR DESCRIPTION
- Remove Opera from compatible browsers list (Opera restricts Web Bluetooth API)
- Add note that other Chromium-based browsers may also work
- Clarify that Opera restricts Web Bluetooth access
- Updated both README.md and index.html for consistency