### PR TITLE
Fix BLE firmware upload failure on small-MTU links (e.g. nRF52)

### DIFF
--- a/__tests__/mcumgr.test.js
+++ b/__tests__/mcumgr.test.js
@@ -30,7 +30,7 @@ describe('MCUManager', () => {
     test('should initialize with default values', () => {
       expect(manager.SERVICE_UUID).toBe('8d53dc1d-1db7-4cd3-868b-8a527460aa84');
       expect(manager.CHARACTERISTIC_UUID).toBe('da2e7828-fbce-4e01-ae9e-261174997c48');
-      expect(manager._mtu).toBe(400);
+      expect(manager._mtu).toBe(244);
       expect(manager._device).toBeNull();
       expect(manager._seq).toBe(0);
       expect(manager._uploadIsInProgress).toBe(false);
@@ -143,8 +143,11 @@ describe('MCUManager', () => {
       await expect(manager.imageInfo(invalidImage.buffer)).rejects.toThrow('Invalid image (wrong load address)');
     });
 
-    test('should reject image with wrong protected TLV area size', async () => {
-      const invalidImage = new Uint8Array(32);
+    test('should reject image with bad protected TLV magic', async () => {
+      // A non-zero protected TLV area is perfectly valid for real MCUboot
+      // images, so we don't reject it. What IS invalid is a declared protected
+      // TLV area whose info header doesn't start with the 0x6908 magic.
+      const invalidImage = new Uint8Array(64);
       // Correct magic bytes
       invalidImage[0] = 0x3d;
       invalidImage[1] = 0xb8;
@@ -155,13 +158,25 @@ describe('MCUManager', () => {
       invalidImage[5] = 0x00;
       invalidImage[6] = 0x00;
       invalidImage[7] = 0x00;
-      // Header size
-      invalidImage[8] = 0x20; // 32 bytes
+      // Header size = 32
+      invalidImage[8] = 0x20;
       invalidImage[9] = 0x00;
-      // Wrong protected TLV area size (should be 0)
-      invalidImage[10] = 0x01;
+      // Protected TLV area size = 8 (non-zero -> code will look for the magic)
+      invalidImage[10] = 0x08;
       invalidImage[11] = 0x00;
-      await expect(manager.imageInfo(invalidImage.buffer)).rejects.toThrow('Invalid image (wrong protected TLV area size)');
+      // Image size = 16
+      invalidImage[12] = 0x10;
+      invalidImage[13] = 0x00;
+      invalidImage[14] = 0x00;
+      invalidImage[15] = 0x00;
+      // Flags = 0
+      invalidImage[16] = 0x00;
+      invalidImage[17] = 0x00;
+      invalidImage[18] = 0x00;
+      invalidImage[19] = 0x00;
+      // At offset headerSize+imageSize = 48 the protected TLV info header must
+      // start with magic 0x6908; leave it zeroed to simulate corruption.
+      await expect(manager.imageInfo(invalidImage.buffer)).rejects.toThrow('Expected protected TLV magic number');
     });
 
     test('should reject image with incorrect image size', async () => {
@@ -222,7 +237,7 @@ describe('MCUManager', () => {
     });
 
     test('should parse valid image info correctly', async () => {
-      const validImage = new Uint8Array(96); // 32 header + 64 image
+      const validImage = new Uint8Array(108); // 32 header + 64 image + 12 TLV trailer
       // Correct magic bytes
       validImage[0] = 0x3d;
       validImage[1] = 0xb8;
@@ -254,6 +269,23 @@ describe('MCUManager', () => {
       validImage[21] = 0x02; // Minor
       validImage[22] = 0x2c; // Revision low byte (300 = 0x012c)
       validImage[23] = 0x01; // Revision high byte
+
+      // Non-protected TLV trailer at offset headerSize+imageSize = 96.
+      // Real MCUboot images always carry this; imageInfo requires it.
+      // Info header: magic 0x6907 + total area size (includes the 4-byte header).
+      validImage[96] = 0x07; // magic low  (0x6907)
+      validImage[97] = 0x69; // magic high
+      validImage[98] = 0x0c; // total TLV area size = 12 (4 header + 8 entry)
+      validImage[99] = 0x00;
+      // One TLV entry: tag=0x0001, len=4, value=0xAABBCCDD
+      validImage[100] = 0x01; // tag low
+      validImage[101] = 0x00; // tag high
+      validImage[102] = 0x04; // len low
+      validImage[103] = 0x00; // len high
+      validImage[104] = 0xaa;
+      validImage[105] = 0xbb;
+      validImage[106] = 0xcc;
+      validImage[107] = 0xdd;
 
       const info = await manager.imageInfo(validImage.buffer);
       expect(info.version).toBe('1.2.300');

--- a/js/mcumgr.js
+++ b/js/mcumgr.js
@@ -37,7 +37,7 @@ class MCUManager {
     constructor(di = {}) {
         this.SERVICE_UUID = '8d53dc1d-1db7-4cd3-868b-8a527460aa84';
         this.CHARACTERISTIC_UUID = 'da2e7828-fbce-4e01-ae9e-261174997c48';
-        this._mtu = 400;
+        this._mtu = 244; // max bytes per ATT write (negotiated ATT MTU - 3). 244 suits a 247-MTU link; the upload path re-measures each frame so the CBOR length prefix can't overflow this.
         this._device = null;
         this._service = null;
         this._characteristic = null;
@@ -324,14 +324,27 @@ class MCUManager {
         }
         this._imageUploadProgressCallback({ percentage: Math.floor(this._uploadOffset / this._uploadImage.byteLength * 100) });
 
-        const length = this._mtu - CBOR.encode(message).byteLength - nmpOverhead;
-
+        // Estimate the chunk size, then re-measure with the real data attached.
+        // CBOR encodes `data` as a byte string whose 1-3 byte length prefix is
+        // NOT present when overhead is measured against empty data above, so the
+        // first estimate can run a few bytes over budget. Shrink until the full
+        // SMP frame (8-byte NMP header + CBOR body) fits one ATT write (_mtu).
+        let length = this._mtu - CBOR.encode(message).byteLength - nmpOverhead;
+        if (length < 1) length = 1;
         message.data = new Uint8Array(this._uploadImage.slice(this._uploadOffset, this._uploadOffset + length));
+        while (length > 1 && nmpOverhead + CBOR.encode(message).byteLength > this._mtu) {
+            length -= 1;
+            message.data = new Uint8Array(this._uploadImage.slice(this._uploadOffset, this._uploadOffset + length));
+        }
 
-        // Keep offset for retry
-        // this._uploadOffset += length;
-
-        this._sendMessage(MGMT_OP_WRITE, MGMT_GROUP_ID_IMAGE, IMG_MGMT_ID_UPLOAD, message);
+        // Surface BLE write failures (e.g. a value larger than the negotiated
+        // ATT MTU) instead of letting them become a silent unhandled rejection
+        // that only ever shows up as an upload timeout.
+        try {
+            await this._sendMessage(MGMT_OP_WRITE, MGMT_GROUP_ID_IMAGE, IMG_MGMT_ID_UPLOAD, message);
+        } catch (e) {
+            this._logger.error(`BLE write failed during upload: ${e && e.message ? e.message : e}. If this persists, lower _mtu.`);
+        }
     }
     async cmdUpload(image, slot = 0) {
         if (this._uploadIsInProgress) {
@@ -397,7 +410,7 @@ class MCUManager {
         const view = new DataView(image);
 
         // check header length
-        if (view.length < 32) {
+        if (view.byteLength < 32) {
             throw new Error('Invalid image (too short file)');
         }
 
@@ -420,7 +433,7 @@ class MCUManager {
         info.imageSize = imageSize;
 
         // check image size is correct
-        if (view.length < imageSize + headerSize) {
+        if (view.byteLength < imageSize + headerSize) {
             throw new Error('Invalid image (wrong image size)');
         }
 


### PR DESCRIPTION
Upload chunks were sized against a hardcoded _mtu=400 and written in a single writeValueWithoutResponse. On links that negotiate a smaller ATT MTU (the nRF52840 firmware here negotiates 247 -> usable payload 244), every upload write exceeded MTU-3 and was dropped, so the device never received a chunk and the upload timed out ("Device not responding after 6 attempts"). Image-state reads still worked because they fit in one packet, which masked the cause.

Changes (js/mcumgr.js):
- _mtu 400 -> 244 (max bytes per ATT write for a 247-MTU link).
- _uploadNext: re-measure the fully-encoded SMP frame (with data attached) and shrink the chunk until 8-byte NMP header + CBOR body fits _mtu. The CBOR byte-string length prefix is not present when overhead is estimated against empty data, so the first estimate could run a few bytes over budget.
- Surface BLE write failures via try/catch + logger.error instead of an unhandled rejection that only showed up as an upload timeout.

Also fix a latent bug in imageInfo(): it used view.length on a DataView, which is always undefined (DataView exposes byteLength). The "too short" and "wrong image size" guards therefore never fired. Use view.byteLength.

Tests:
- Update _mtu constructor assertion (400 -> 244).
- Rewrite the "protected TLV area size" test: a non-zero protected TLV area is valid for real images; instead assert that a bad protected TLV magic throws.
- Add the mandatory non-protected TLV trailer to the valid-image fixture so it parses end-to-end (real MCUboot images always carry it).

All 73 tests pass.